### PR TITLE
added "Export PNG" button to the JPlotterCanvas Panel

### DIFF
--- a/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerPanel.java
+++ b/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerPanel.java
@@ -1,5 +1,7 @@
 package hageldave.jplotter.debugging.ui;
 
+import hageldave.imagingkit.core.Img;
+import hageldave.imagingkit.core.io.ImageSaver;
 import hageldave.jplotter.canvas.JPlotterCanvas;
 import hageldave.jplotter.debugging.annotations.DebugGetter;
 import hageldave.jplotter.debugging.annotations.DebugSetter;
@@ -272,6 +274,9 @@ class DebuggerPanel extends JPanel {
         JButton exportPdfBtn = new JButton("Export PDF");
         exportPdfBtn.setToolTipText("Exports the canvas as a .pdf file to the root of the project.");
 
+        JButton exportPngBtn = new JButton("Export PNG");
+        exportPngBtn.setToolTipText("Exports the canvas as a .png file to the root of the project.");
+
         exportSvgBtn.addActionListener(e -> {
             String timeSubstring = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(':', '-');
             String fileName = "export-" + timeSubstring + ".svg";
@@ -291,12 +296,20 @@ class DebuggerPanel extends JPanel {
             }
         });
 
+        exportPngBtn.addActionListener(e -> {
+            String timeSubstring = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(':', '-');
+            Img img = new Img(canvas.asComponent().getSize());
+            img.paint(g -> canvas.asComponent().paintAll(g));
+            ImageSaver.saveImage(img.getRemoteBufferedImage(), "export-" + timeSubstring + ".png");
+        });
+
         title.setText(canvas.getClass().getSimpleName());
         controlHeader.setText("Export canvas");
 
         exportPanel.setLayout(new BoxLayout(exportPanel, BoxLayout.X_AXIS));
         exportPanel.add(exportSvgBtn);
         exportPanel.add(exportPdfBtn);
+        exportPanel.add(exportPngBtn);
 
         exportPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         controlContainer.add(exportPanel);

--- a/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerPanel.java
+++ b/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerPanel.java
@@ -277,11 +277,15 @@ class DebuggerPanel extends JPanel {
         JButton exportPngBtn = new JButton("Export PNG");
         exportPngBtn.setToolTipText("Exports the canvas as a .png file to the root of the project.");
 
+        JButton exportAllBtn = new JButton("Export All");
+        exportAllBtn.setToolTipText("Exports the canvas as .svg, .pdf and .png files to the root of the project.");
+
         exportSvgBtn.addActionListener(e -> {
             String timeSubstring = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(':', '-');
             String fileName = "export-" + timeSubstring + ".svg";
             Document doc = canvas.paintSVG();
             SVGUtils.documentToXMLFile(doc, new File(fileName));
+            System.out.println("Successfully exported as .svg file.");
         });
 
         exportPdfBtn.addActionListener(e -> {
@@ -291,6 +295,7 @@ class DebuggerPanel extends JPanel {
                 PDDocument doc = canvas.paintPDF();
                 doc.save(fileName);
                 doc.close();
+                System.out.println("Successfully exported as .pdf file.");
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }
@@ -301,6 +306,27 @@ class DebuggerPanel extends JPanel {
             Img img = new Img(canvas.asComponent().getSize());
             img.paint(g -> canvas.asComponent().paintAll(g));
             ImageSaver.saveImage(img.getRemoteBufferedImage(), "export-" + timeSubstring + ".png");
+            System.out.println("Successfully exported as .png file.");
+        });
+
+        exportAllBtn.addActionListener(e -> {
+            String timeSubstring = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS).toString().replace(':', '-');
+            Document svgDoc = canvas.paintSVG();
+            SVGUtils.documentToXMLFile(svgDoc, new File("export-" + timeSubstring + ".svg"));
+
+            try {
+                PDDocument pdfDoc = canvas.paintPDF();
+                pdfDoc.save("export-" + timeSubstring + ".pdf");
+                pdfDoc.close();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+
+            Img img = new Img(canvas.asComponent().getSize());
+            img.paint(g -> canvas.asComponent().paintAll(g));
+            ImageSaver.saveImage(img.getRemoteBufferedImage(), "export-" + timeSubstring + ".png");
+
+            System.out.println("Successfully exported as .svg, .pdf and .png files.");
         });
 
         title.setText(canvas.getClass().getSimpleName());
@@ -310,6 +336,7 @@ class DebuggerPanel extends JPanel {
         exportPanel.add(exportSvgBtn);
         exportPanel.add(exportPdfBtn);
         exportPanel.add(exportPngBtn);
+        exportPanel.add(exportAllBtn);
 
         exportPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
         controlContainer.add(exportPanel);

--- a/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerUI.java
+++ b/jplotter/src/main/java/hageldave/jplotter/debugging/ui/DebuggerUI.java
@@ -5,6 +5,8 @@ import hageldave.jplotter.canvas.JPlotterCanvas;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -29,6 +31,14 @@ public class DebuggerUI {
     public DebuggerUI(JPlotterCanvas... canvases) {
         for (JPlotterCanvas c: canvases) {
             this.debuggerList.add(new DebuggerPanel(c));
+
+            c.asComponent().addComponentListener(new ComponentAdapter() {
+                @Override
+                public void componentResized(ComponentEvent e) {
+                    super.componentResized(e);
+                    refresh();
+                }
+            });
         }
         display();
     }
@@ -41,6 +51,14 @@ public class DebuggerUI {
      */
     public DebuggerUI(JPlotterCanvas canvas) {
         this.debuggerList.add(new DebuggerPanel(canvas));
+
+        canvas.asComponent().addComponentListener(new ComponentAdapter() {
+            @Override
+            public void componentResized(ComponentEvent e) {
+                super.componentResized(e);
+                refresh();
+            }
+        });
         display();
     }
 


### PR DESCRIPTION
Just added a new button to the JPlotterCanvas panel, that exports to PNG.
This complements the SVG/PDF buttons, as shown in the screenshot:

![image](https://user-images.githubusercontent.com/52721603/235988627-fd48d8e4-04e0-4baf-a920-9f2f12b21a94.png)
